### PR TITLE
Bumped dependencies for node 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   },
   "devDependencies": {
     "grunt": "~0.4.1",
-    "grunt-simple-mocha": "~0.3.2",
-    "request": "~2.14.0"
+    "grunt-simple-mocha": "~0.4.0",
+    "request": "~2.21.0"
   },
   "peerDependencies": {
     "grunt": "~0.4.0"


### PR DESCRIPTION
Fails due to the usual path join nonsense with the old simple-mocha version, otherwise.
