### PR TITLE
Adding a new option 'bin' to define the path of the PHP binary

### DIFF
--- a/tasks/php.js
+++ b/tasks/php.js
@@ -30,12 +30,17 @@ module.exports = function (grunt) {
 		});
 		var host = options.hostname + ':' + options.port;
 		var args = ['-S', host];
-
+		var bin = 'php';
+		
 		if (options.router) {
 			args.push(options.router);
 		}
 
-		var cp = spawn('php', args, {
+		if( options.bin) {
+			bin = options.bin;
+		}
+
+		var cp = spawn(bin, args, {
 			cwd: path.resolve(options.base),
 			stdio: 'inherit'
 		});


### PR DESCRIPTION
Hi,

I've got multiple PHP Versions installed on my machine. So I've added a new option "bin" which defines the file path of a PHP binary.

Patrick
