### PR TITLE
Fixed server not considered up when no index file

### DIFF
--- a/tasks/php.js
+++ b/tasks/php.js
@@ -13,7 +13,7 @@ module.exports = function (grunt) {
 				hostname: hostname,
 				port: port
 			}, function (res) {
-				if (res.statusCode === 200) {
+				if (res.statusCode === 200 || res.statusCode === 404) {
 					return cb();
 				}
 


### PR DESCRIPTION
HTTP `404` return code should be considered as a success when checking if server is alive or not. For instance, this is happening when index file is missing from current directory.
