### PR TITLE
PHP blocking & not allowing next grunt task

### DIFF
--- a/tasks/php.js
+++ b/tasks/php.js
@@ -4,30 +4,6 @@ module.exports = function (grunt) {
 	var spawn = require('child_process').spawn;
 	var http = require('http');
 	var open = require('open');
-	var checkServerTries = 0;
-
-	function checkServer(hostname, port, cb) {
-		setTimeout(function () {
-			http.request({
-				method: 'HEAD',
-				hostname: hostname,
-				port: port
-			}, function (res) {
-				if (res.statusCode === 200 || res.statusCode === 404) {
-					return cb();
-				}
-
-				checkServer(hostname, port, cb);
-			}).on('error', function (err) {
-				// back off after 1s
-				if (++checkServerTries > 20) {
-					return cb();
-				}
-
-				checkServer(hostname, port, cb);
-			}).end();
-		}, 50);
-	}
 
 	grunt.registerMultiTask('php', 'Start a PHP-server', function () {
 		var cb = this.async();
@@ -56,16 +32,10 @@ module.exports = function (grunt) {
 			cp.kill();
 		});
 
-		// check when the server is ready. tried doing it by listening
-		// to the child process `data` event, but it's not triggered...
-		checkServer(options.hostname, options.port, function () {
-			if (!this.flags.keepalive && !options.keepalive) {
-				cb();
-			}
+		if (options.open) {
+			open('http://' + host);
+		}
 
-			if (options.open) {
-				open('http://' + host);
-			}
-		}.bind(this));
+		cb();
 	});
 };


### PR DESCRIPTION
Hey,

This is probably the worst pull request I have done as I've basically just deleted a load of the code to make this work however you may like it ;)

Basically, the checkServer function was preventing the php from going to the background as expected with spawn.

From what I could see, it never reached the 'checkServerTries' limit on line 23, I only managed to get it iterate 8 times maximum till it hung.

I hope this helps.... I will probably take another look at a solution if you really need 'check server' however I figured it was unnecessary.

Let me know.
