### PR TITLE
Run TravisCI against Node versions instead of PHP versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "0.10"
 before_install:
   - sudo add-apt-repository "deb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse" -y
+  - sudo apt-get update -qq
   - sudo apt-get install -t trusty php5-cli
 script:
   - npm test


### PR DESCRIPTION
Since this is ultimately a node.js application and not a PHP application we should test our code against supported versions of our interpreter.

**NOTE: This PR may fail if Travis does not offer a PHP binary on their node VMs.**
