### PR TITLE
-c option (php.ini) before the last command (router)

### DIFF
--- a/tasks/php.js
+++ b/tasks/php.js
@@ -52,13 +52,14 @@ module.exports = function (grunt) {
 		var host = options.hostname + ':' + options.port;
 		var args = ['-S', host];
 
+		if (options.ini) {
+			args.push('-c', options.ini);
+		}
+
 		if (options.router) {
 			args.push(options.router);
 		}
 
-		if (options.ini) {
-			args.push('-c', options.ini);
-		}
 
 		binVersionCheck(options.bin, '>=5.4', function (err) {
 			if (err) {


### PR DESCRIPTION
At least on some versions of php-cli you need to specify the -c option _before_ the router command.
This works as expected:
`php -S localhost:8080 -c php.ini router.php`

The current behaviour, doesn't works (php.ini file is ignored):
`php -S localhost:8080 router.php -c php.ini`

This patch ensures that the router option is the last.
