### PR TITLE
Correct proxy settings for BrowserSync

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ grunt.initConfig({
 				]
 			},
 			options: {
-				proxy: '<%= php.serve.options.hostname %>:<%= php.serve.options.port %>',
+				proxy: '<%= php.dist.options.hostname %>:<%= php.dist.options.port %>',
 				watchTask: true,
 				notify: true,
 				open: true,


### PR DESCRIPTION
In the example, the php hostname and port is filed under php.dist and not php.serve. In order to give a proper example, this has to be corrected. Sorry, @sindresorhus!
