### PR TITLE
Output: add option to set stdio on the spawn call to suppress php output

### DIFF
--- a/tasks/php.js
+++ b/tasks/php.js
@@ -47,7 +47,8 @@ module.exports = function (grunt) {
 			base: '.',
 			keepalive: false,
 			open: false,
-			bin: 'php'
+			bin: 'php',
+			stdio: "inherit"
 		});
 		var host = options.hostname + ':' + options.port;
 		var args = ['-S', host];
@@ -69,8 +70,7 @@ module.exports = function (grunt) {
 			}
 
 			var cp = spawn(options.bin, args, {
-				cwd: options.base,
-				stdio: 'inherit'
+				cwd: options.base
 			});
 
 			// quit PHP when grunt is done


### PR DESCRIPTION
I am trying to set this up to be able to run jQuery core tests via travisCI. One problem im facing right now is that all output from php is being piped directly to stdio which means when running qunit tests the there is tons of php output in the middle of the test output and its really really ugly. By being able to set the stdio option the php output could be suppressed giving readable test results. 