### PR TITLE
Use a system assigned port if `0` or `?` is specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "bin-version-check": "^2.0.0",
+    "get-port": "^1.0.0",
     "opn": "^1.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -123,7 +123,7 @@ grunt.registerTask('phpwatch', ['php:watch', 'watch']);
 Type: `number`  
 Default: `8000`
 
-The port on which you want to access the webserver. Task will fail if the port is already in use.
+The port on which you want to access the webserver. Task will fail if the port is already in use. Use the special value `?` to use a system-assigned port.
 
 ### hostname
 

--- a/tasks/php.js
+++ b/tasks/php.js
@@ -3,6 +3,7 @@ var spawn = require('child_process').spawn;
 var http = require('http');
 var open = require('opn');
 var binVersionCheck = require('bin-version-check');
+var getPort = require('get-port');
 
 module.exports = function (grunt) {
 	var checkServerTries = 0;
@@ -49,45 +50,57 @@ module.exports = function (grunt) {
 			open: false,
 			bin: 'php'
 		});
-		var host = options.hostname + ':' + options.port;
-		var args = ['-S', host];
 
-		if (options.ini) {
-			args.push('-c', options.ini);
-		}
-
-		if (options.router) {
-			args.push(options.router);
-		}
-
-
-		binVersionCheck(options.bin, '>=5.4', function (err) {
+		getPort(function (err, port) {
 			if (err) {
 				grunt.warn(err);
 				cb();
 				return;
 			}
 
-			var cp = spawn(options.bin, args, {
-				cwd: options.base,
-				stdio: 'inherit'
-			});
+			if (options.port === '?') {
+				options.port = port;
+			}
 
-			// quit PHP when grunt is done
-			process.on('exit', function () {
-				cp.kill();
-			});
+			var host = options.hostname + ':' + options.port;
+			var args = ['-S', host];
 
-			// check when the server is ready. tried doing it by listening
-			// to the child process `data` event, but it's not triggered...
-			checkServer(options.hostname, options.port, function () {
-				if (!this.flags.keepalive && !options.keepalive) {
+			if (options.ini) {
+				args.push('-c', options.ini);
+			}
+
+			if (options.router) {
+				args.push(options.router);
+			}
+
+			binVersionCheck(options.bin, '>=5.4', function (err) {
+				if (err) {
+					grunt.warn(err);
 					cb();
+					return;
 				}
 
-				if (options.open) {
-					open('http://' + host);
-				}
+				var cp = spawn(options.bin, args, {
+					cwd: options.base,
+					stdio: 'inherit'
+				});
+
+				// quit PHP when grunt is done
+				process.on('exit', function () {
+					cp.kill();
+				});
+
+				// check when the server is ready. tried doing it by listening
+				// to the child process `data` event, but it's not triggered...
+				checkServer(options.hostname, options.port, function () {
+					if (!this.flags.keepalive && !options.keepalive) {
+						cb();
+					}
+
+					if (options.open) {
+						open('http://' + host);
+					}
+				}.bind(this));
 			}.bind(this));
 		}.bind(this));
 	});


### PR DESCRIPTION
Having to run `get-port` even if you specified a port might be a small drawback but shouldn't matter too much since you probably aren't starting and stopping the server too often.

Fixes #35.