### PR TITLE
Add `silent` option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,13 @@ Default: Built-in `php.ini`
 
 Path to a custom [`php.ini`](http://php.net/manual/en/ini.php) config file.
 
+### silent
+
+Type: `boolean`
+Default: `false`
+
+Suppress output produced by the PHP server.
+
 
 ## License
 

--- a/tasks/php.js
+++ b/tasks/php.js
@@ -50,6 +50,7 @@ module.exports = function (grunt) {
 			keepalive: false,
 			open: false,
 			bin: 'php',
+			silent: false,
 			env: {}
 		});
 
@@ -84,7 +85,7 @@ module.exports = function (grunt) {
 
 				var cp = spawn(options.bin, args, {
 					cwd: options.base,
-					stdio: 'inherit',
+					stdio: options.silent ? 'ignore' : 'inherit',
 					env: objectAssign({}, process.env, options.env)
 				});
 


### PR DESCRIPTION
Disables `process.stdout` and `process.stderr`. I think we could disable `process.stdin` too (since it isn't used?).

Fixes #58.