### PR TITLE
fix issue #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+#IDE
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,1 @@
 node_modules
-#IDE
-.idea

--- a/.jscsrc
+++ b/.jscsrc
@@ -2,5 +2,6 @@
 	"preset": "grunt",
 	"disallowSpacesInAnonymousFunctionExpression": null,
 	"requireLineFeedAtFileEnd": true,
-	"validateIndentation": "\t"
+	"validateIndentation": "\t",
+	"requirePaddingNewLinesAfterBlocks": true
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bin-version-check": "^2.0.0",
     "get-port": "^1.0.0",
     "object-assign": "^2.0.0",
+    "onetime": "^1.0.0",
     "opn": "^1.0.0"
   },
   "devDependencies": {

--- a/tasks/php.js
+++ b/tasks/php.js
@@ -8,8 +8,9 @@ var objectAssign = require('object-assign');
 
 module.exports = function (grunt) {
 	var checkServerTries = 0;
+	var serverStarted = false;
 
-	function checkServer(hostname, port, path, cb) {
+	function checkServer(hostname, port, path, done) {
 		setTimeout(function () {
 			http.request({
 				method: 'HEAD',
@@ -19,30 +20,41 @@ module.exports = function (grunt) {
 			}, function (res) {
 				var statusCodeType = Number(res.statusCode.toString()[0]);
 				if ([2, 3, 4].indexOf(statusCodeType) !== -1) {
-					return cb();
+					if (!serverStarted) {
+						serverStarted = true;
+						done(true);
+					}
+					return;
 				} else if (statusCodeType === 5) {
 					grunt.fail.warn(
 						'Server docroot returned 500-level response. Please check ' +
 						'your configuration for possible errors.'
 					);
-					return cb();
+					if (!serverStarted) {
+						serverStarted = true;
+						done(true);
+					}
+					return;
 				}
-
-				checkServer(hostname, port, path, cb);
+				checkServer(hostname, port, path, done);
 			}).on('error', function (err) {
 				// back off after 1s
-				if (++checkServerTries > 20) {
-					return cb();
+				if (!serverStarted) {
+					if (++checkServerTries > 20) {
+						return done(false);
+					}
+					grunt.verbose.writeln('PHP server not started. Retrying...');
+					checkServer(hostname, port, path, done);
 				}
-
-				grunt.verbose.writeln('PHP server not started. Retrying...');
-				checkServer(hostname, port, path, cb);
 			}).end();
 		}, 50);
 	}
 
 	grunt.registerMultiTask('php', 'Start a PHP-server', function () {
-		var cb = this.async();
+		checkServerTries = 0;
+		serverStarted = false;
+
+		var done = this.async();
 		var options = this.options({
 			port: 8000,
 			hostname: '127.0.0.1',
@@ -58,7 +70,7 @@ module.exports = function (grunt) {
 		getPort(function (err, port) {
 			if (err) {
 				grunt.warn(err);
-				cb();
+				done(false);
 				return;
 			}
 
@@ -86,7 +98,7 @@ module.exports = function (grunt) {
 			binVersionCheck(options.bin, '>=5.4', function (err) {
 				if (err) {
 					grunt.warn(err);
-					cb();
+					done(false);
 					return;
 				}
 
@@ -109,7 +121,7 @@ module.exports = function (grunt) {
 				// to the child process `data` event, but it's not triggered...
 				checkServer(options.hostname, options.port, path, function () {
 					if (!this.flags.keepalive && !options.keepalive) {
-						cb();
+						done(true);
 					}
 
 					if (options.open) {

--- a/tasks/php.js
+++ b/tasks/php.js
@@ -5,6 +5,7 @@ var open = require('opn');
 var binVersionCheck = require('bin-version-check');
 var getPort = require('get-port');
 var objectAssign = require('object-assign');
+var onetime = require('onetime');
 
 module.exports = function (grunt) {
 	var checkServerTries = 0;
@@ -24,6 +25,7 @@ module.exports = function (grunt) {
 						serverStarted = true;
 						done(true);
 					}
+
 					return;
 				} else if (statusCodeType === 5) {
 					grunt.fail.warn(
@@ -34,8 +36,10 @@ module.exports = function (grunt) {
 						serverStarted = true;
 						done(true);
 					}
+
 					return;
 				}
+
 				checkServer(hostname, port, path, done);
 			}).on('error', function (err) {
 				// back off after 1s
@@ -43,6 +47,7 @@ module.exports = function (grunt) {
 					if (++checkServerTries > 20) {
 						return done(false);
 					}
+
 					grunt.verbose.writeln('PHP server not started. Retrying...');
 					checkServer(hostname, port, path, done);
 				}
@@ -54,7 +59,7 @@ module.exports = function (grunt) {
 		checkServerTries = 0;
 		serverStarted = false;
 
-		var done = this.async();
+		var done = onetime(this.async(), true);
 		var options = this.options({
 			port: 8000,
 			hostname: '127.0.0.1',


### PR DESCRIPTION
#17 was caused by a randomly occuring issue in checkServer: in *some* circumstances (sorry, did not manage to devise a reproducible test), `http.request({method: 'HEAD',...})` returns a statusCode of 2 but also an error ('HPE_INVALID_CONSTANT').

As a result this.async was called **twice** (once in the original request callback, and then again in the request, initiated by the error handler).
I suppose grunt interpreted the second call as the end of the following task (watch) if it had already starded, and ended the build.

I added a check so this.async is only ever called once. I also did a little renaming and used false/true value to signal task failure to grunt.